### PR TITLE
Scan Book Barcodes

### DIFF
--- a/smart-library-app.xcodeproj/project.pbxproj
+++ b/smart-library-app.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2741A3F628ED804F00D4E14B /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2741A3F528ED804F00D4E14B /* HomeView.swift */; };
 		F814595B28DDA63D00390B65 /* smart_library_appApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F814595A28DDA63D00390B65 /* smart_library_appApp.swift */; };
 		F814595D28DDA63D00390B65 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F814595C28DDA63D00390B65 /* ContentView.swift */; };
 		F814595F28DDA64200390B65 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F814595E28DDA64200390B65 /* Assets.xcassets */; };
@@ -19,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2741A3F528ED804F00D4E14B /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		F814595728DDA63C00390B65 /* smart-library-app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "smart-library-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F814595A28DDA63D00390B65 /* smart_library_appApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = smart_library_appApp.swift; sourceTree = "<group>"; };
 		F814595C28DDA63D00390B65 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -43,6 +45,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2741A3F428ED803A00D4E14B /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				2741A3F528ED804F00D4E14B /* HomeView.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
 		F814594E28DDA63C00390B65 = {
 			isa = PBXGroup;
 			children = (
@@ -62,6 +72,7 @@
 		F814595928DDA63D00390B65 /* smart-library-app */ = {
 			isa = PBXGroup;
 			children = (
+				2741A3F428ED803A00D4E14B /* Home */,
 				F895D6BE28E95D950042A38C /* Search */,
 				F814595A28DDA63D00390B65 /* smart_library_appApp.swift */,
 				F814595C28DDA63D00390B65 /* ContentView.swift */,
@@ -175,6 +186,7 @@
 				F814595D28DDA63D00390B65 /* ContentView.swift in Sources */,
 				F8722D9628E942A30037C751 /* VolumeData.swift in Sources */,
 				F8722D9928E945F10037C751 /* BookDatabase.swift in Sources */,
+				2741A3F628ED804F00D4E14B /* HomeView.swift in Sources */,
 				F8357C7328E6F234005E4C5E /* SearchView.swift in Sources */,
 				F814595B28DDA63D00390B65 /* smart_library_appApp.swift in Sources */,
 			);

--- a/smart-library-app.xcodeproj/project.pbxproj
+++ b/smart-library-app.xcodeproj/project.pbxproj
@@ -321,7 +321,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"smart-library-app/Preview Content\"";
-				DEVELOPMENT_TEAM = 8RR2857BQ4;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -340,7 +340,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.rileykeane.smart-library-app";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.emmapainter.smart-library-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -359,7 +359,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"smart-library-app/Preview Content\"";
-				DEVELOPMENT_TEAM = 8RR2857BQ4;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -378,7 +378,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.rileykeane.smart-library-app";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.emmapainter.smart-library-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";

--- a/smart-library-app.xcodeproj/project.pbxproj
+++ b/smart-library-app.xcodeproj/project.pbxproj
@@ -321,7 +321,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"smart-library-app/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 8RR2857BQ4;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -340,7 +340,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.emmapainter.smart-library-app";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rileykeane.smart-library-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
@@ -359,7 +359,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"smart-library-app/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 8RR2857BQ4;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -378,7 +378,7 @@
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.emmapainter.smart-library-app";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.rileykeane.smart-library-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";

--- a/smart-library-app.xcodeproj/project.pbxproj
+++ b/smart-library-app.xcodeproj/project.pbxproj
@@ -325,6 +325,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Access to your camera is required to scan the book barcode";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -363,6 +364,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Access to your camera is required to scan the book barcode";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/smart-library-app.xcodeproj/project.pbxproj
+++ b/smart-library-app.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2741A3F628ED804F00D4E14B /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2741A3F528ED804F00D4E14B /* HomeView.swift */; };
+		2741A3FC28ED8E3200D4E14B /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = 2741A3FB28ED8E3200D4E14B /* CodeScanner */; };
 		F814595B28DDA63D00390B65 /* smart_library_appApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F814595A28DDA63D00390B65 /* smart_library_appApp.swift */; };
 		F814595D28DDA63D00390B65 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F814595C28DDA63D00390B65 /* ContentView.swift */; };
 		F814595F28DDA64200390B65 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F814595E28DDA64200390B65 /* Assets.xcassets */; };
@@ -39,6 +40,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2741A3FC28ED8E3200D4E14B /* CodeScanner in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -127,6 +129,9 @@
 			dependencies = (
 			);
 			name = "smart-library-app";
+			packageProductDependencies = (
+				2741A3FB28ED8E3200D4E14B /* CodeScanner */,
+			);
 			productName = "smart-library-app";
 			productReference = F814595728DDA63C00390B65 /* smart-library-app.app */;
 			productType = "com.apple.product-type.application";
@@ -155,6 +160,9 @@
 				Base,
 			);
 			mainGroup = F814594E28DDA63C00390B65;
+			packageReferences = (
+				2741A3FA28ED8E3200D4E14B /* XCRemoteSwiftPackageReference "CodeScanner" */,
+			);
 			productRefGroup = F814595828DDA63C00390B65 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -402,6 +410,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		2741A3FA28ED8E3200D4E14B /* XCRemoteSwiftPackageReference "CodeScanner" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/twostraws/CodeScanner";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		2741A3FB28ED8E3200D4E14B /* CodeScanner */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2741A3FA28ED8E3200D4E14B /* XCRemoteSwiftPackageReference "CodeScanner" */;
+			productName = CodeScanner;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = F814594F28DDA63C00390B65 /* Project object */;
 }

--- a/smart-library-app/BookDatabase.swift
+++ b/smart-library-app/BookDatabase.swift
@@ -65,4 +65,10 @@ class BookDatabase: NSObject {
         currentRequestIndex = 0
         searchGoogleBooksFor(text: text, completion: completion)
     }
+    
+    func getBookByIsbn(isbn: String, completion:@escaping (BookData?) -> ()) {
+        searchAllBooksFor(text: isbn, completion: {(books) -> Void in
+            completion(books.first)
+        })
+    }
 }

--- a/smart-library-app/BookDatabase.swift
+++ b/smart-library-app/BookDatabase.swift
@@ -69,6 +69,7 @@ class BookDatabase: NSObject {
     func getBookByIsbn(isbn: String, completion:@escaping (BookData?) -> ()) {
         searchAllBooksFor(text: isbn, completion: {(books) -> Void in
             completion(books.first)
+            self.terminateSearch()
         })
     }
 }

--- a/smart-library-app/Home/HomeView.swift
+++ b/smart-library-app/Home/HomeView.swift
@@ -6,12 +6,42 @@
 //
 
 import SwiftUI
+import CodeScanner
 
 struct HomeView: View {
+    
+    @State private var isShowingScanner = false
+    @State private var scannedISBN = ""
+    
     var body: some View {
-        Button("Scan") {
-            print("Hello, world")
+        NavigationStack {
+            VStack {
+                Button("Scan your book") {
+                    isShowingScanner = true
+                }
+                Text(scannedISBN)
+                    .padding(10)
+                
+            }
+            .navigationTitle("Home")
         }
+        .sheet(isPresented: $isShowingScanner) {
+            CodeScannerView(codeTypes: [.ean13], simulatedData: "9780804139298", completion: handleScan)
+        }
+        
+    }
+    
+    func handleScan(result: Result<ScanResult, ScanError>) {
+        isShowingScanner = false
+        
+        switch result {
+        case .success(let result):
+            scannedISBN = result.string
+        case .failure(let error):
+            // TODO: RK - Error handling
+            print("Something went wrong... \(error.localizedDescription)")
+        }
+        
     }
 }
 

--- a/smart-library-app/Home/HomeView.swift
+++ b/smart-library-app/Home/HomeView.swift
@@ -41,12 +41,13 @@ struct HomeView: View {
     
     func handleScan(result: Result<ScanResult, ScanError>) {
         isShowingScanner = false
+        scannedBook = nil
         
         switch result {
         case .success(let result):
-            scannedBook = nil
             isLoading = true
             let scannedISBN = result.string
+            
             bookDatabase.getBookByIsbn(isbn: scannedISBN, completion: {(book) -> Void in
                 scannedBook = book
                 isLoading = false

--- a/smart-library-app/Home/HomeView.swift
+++ b/smart-library-app/Home/HomeView.swift
@@ -6,42 +6,12 @@
 //
 
 import SwiftUI
-import CodeScanner
 
 struct HomeView: View {
-    
-    @State private var isShowingScanner = false
-    @State private var scannedISBN = ""
-    
     var body: some View {
-        NavigationStack {
-            VStack {
-                Button("Scan your book") {
-                    isShowingScanner = true
-                }
-                Text(scannedISBN)
-                    .padding(10)
-                
-            }
-            .navigationTitle("Home")
+        Button("Scan") {
+            print("Hello, world")
         }
-        .sheet(isPresented: $isShowingScanner) {
-            CodeScannerView(codeTypes: [.ean13], simulatedData: "9780804139298", completion: handleScan)
-        }
-        
-    }
-    
-    func handleScan(result: Result<ScanResult, ScanError>) {
-        isShowingScanner = false
-        
-        switch result {
-        case .success(let result):
-            scannedISBN = result.string
-        case .failure(let error):
-            // TODO: RK - Error handling
-            print("Something went wrong... \(error.localizedDescription)")
-        }
-        
     }
 }
 

--- a/smart-library-app/Home/HomeView.swift
+++ b/smart-library-app/Home/HomeView.swift
@@ -11,7 +11,9 @@ import CodeScanner
 struct HomeView: View {
     
     @State private var isShowingScanner = false
-    @State private var scannedISBN = ""
+    @State private var scannedBook: BookData?
+    
+    let bookDatabase = BookDatabase()
     
     var body: some View {
         NavigationStack {
@@ -19,14 +21,14 @@ struct HomeView: View {
                 Button("Scan your book") {
                     isShowingScanner = true
                 }
-                Text(scannedISBN)
+                Text(scannedBook?.title ?? "")
                     .padding(10)
                 
             }
             .navigationTitle("Home")
         }
         .sheet(isPresented: $isShowingScanner) {
-            CodeScannerView(codeTypes: [.ean13], simulatedData: "9780804139298", completion: handleScan)
+            CodeScannerView(codeTypes: [.ean13], simulatedData: "‎9780439708180", completion: handleScan)
         }
         
     }
@@ -36,7 +38,10 @@ struct HomeView: View {
         
         switch result {
         case .success(let result):
-            scannedISBN = result.string
+            let scannedISBN = result.string
+            bookDatabase.getBookByIsbn(isbn: scannedISBN, completion: {(book) -> Void in
+                scannedBook = book
+            })
         case .failure(let error):
             // TODO: RK - Error handling
             print("Something went wrong... \(error.localizedDescription)")

--- a/smart-library-app/Home/HomeView.swift
+++ b/smart-library-app/Home/HomeView.swift
@@ -38,6 +38,7 @@ struct HomeView: View {
         
         switch result {
         case .success(let result):
+            scannedBook = nil
             let scannedISBN = result.string
             bookDatabase.getBookByIsbn(isbn: scannedISBN, completion: {(book) -> Void in
                 scannedBook = book

--- a/smart-library-app/Home/HomeView.swift
+++ b/smart-library-app/Home/HomeView.swift
@@ -12,6 +12,7 @@ struct HomeView: View {
     
     @State private var isShowingScanner = false
     @State private var scannedBook: BookData?
+    @State private var isLoading = false
     
     let bookDatabase = BookDatabase()
     
@@ -21,8 +22,13 @@ struct HomeView: View {
                 Button("Scan your book") {
                     isShowingScanner = true
                 }
-                Text(scannedBook?.title ?? "")
+                if (isLoading) {
+                    ProgressView()
                     .padding(10)
+                } else {
+                    Text(scannedBook?.title ?? "")
+                    .padding(10)
+                }
                 
             }
             .navigationTitle("Home")
@@ -39,9 +45,11 @@ struct HomeView: View {
         switch result {
         case .success(let result):
             scannedBook = nil
+            isLoading = true
             let scannedISBN = result.string
             bookDatabase.getBookByIsbn(isbn: scannedISBN, completion: {(book) -> Void in
                 scannedBook = book
+                isLoading = false
             })
         case .failure(let error):
             // TODO: RK - Error handling

--- a/smart-library-app/Home/HomeView.swift
+++ b/smart-library-app/Home/HomeView.swift
@@ -1,0 +1,22 @@
+//
+//  HomeView.swift
+//  smart-library-app
+//
+//  Created by Riley Keane on 10/5/22.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        Button("Scan") {
+            print("Hello, world")
+        }
+    }
+}
+
+struct HomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeView()
+    }
+}

--- a/smart-library-app/smart_library_appApp.swift
+++ b/smart-library-app/smart_library_appApp.swift
@@ -21,7 +21,7 @@ struct smart_library_appApp: App {
     var body: some Scene {
         WindowGroup {
             TabView {
-                ContentView()
+                HomeView()
                     .tabItem {
                         Label("Home", systemImage: "house")
                     }


### PR DESCRIPTION
Added in the ability to scan a books barcode and fetch it from the Google books API

Nothing has been done for designs, it's purely functional at this point. When a barcode is successfully scanned, it returns a BookData object, I'm currently just displaying the title on the home screen. 

In the simulator, it's just using mock data (Harry Potter of course ⚡️), but if you run it on your phone, you can scan actual barcodes. You can also update simulatedData on line 37 in HomeView.swift if you want to test out different ISBNs in the simulator. 

SwiftUI does not have a barcode/QR code scanner, so I used the library [here](https://github.com/twostraws/CodeScanner) which has already ported over the QR scanner from the AVKit UIKit framework. When you test out this PR, you may need to add the library. To do this go to...

File > Add packages > Search for https://github.com/twostraws/CodeScanner > CodeScanner > Add Package > Add Package (again) 
