### PR TITLE
Fix app crashing when book has no sessions

### DIFF
--- a/smart-library-app/Components/MinutesPerDayChart.swift
+++ b/smart-library-app/Components/MinutesPerDayChart.swift
@@ -13,16 +13,22 @@ struct MinutesPerDayChart: View {
     
     var body: some View {
         VStack {
-            Chart {
-                ForEach(readingSessions) { session in
-                    BarMark(
-                        x: .value("Day", session.startTime, unit: .day),
-                        y: .value("Minutes", session.getTimeReading() ?? 0)
-                    )
+            if (readingSessions.count == 0) {
+                Text("Your reading stats will display once you start reading")
+                    .foregroundColor(Color.gray)
+                    .multilineTextAlignment(.center)
+            } else {
+                Chart {
+                    ForEach(readingSessions) { session in
+                        BarMark(
+                            x: .value("Day", session.startTime, unit: .day),
+                            y: .value("Minutes", session.getTimeReading() ?? 0)
+                        )
+                    }
                 }
+                .frame(height: 250)
+                .padding()
             }
-            .frame(height: 250)
-            .padding()
         }
     }
 }

--- a/smart-library-app/Components/PagesPerDayChart.swift
+++ b/smart-library-app/Components/PagesPerDayChart.swift
@@ -13,16 +13,23 @@ struct PagesPerDayChart: View {
     
     var body: some View {
         VStack {
-            Chart {
-                ForEach(readingSessions) { session in
-                    BarMark(
-                        x: .value("Day", session.startTime, unit: .day),
-                        y: .value("Pages", session.numberOfPages ?? 0)
-                    )
+            if (readingSessions.count == 0) {
+                Text("Your reading stats will display once you start reading")
+                    .foregroundColor(Color.gray)
+                    .multilineTextAlignment(.center)
+            } else {
+                Chart {
+                    ForEach(readingSessions) { session in
+                        BarMark(
+                            x: .value("Day", session.startTime, unit: .day),
+                            y: .value("Pages", session.numberOfPages ?? 0)
+                        )
+                    }
                 }
+                .frame(height: 250)
+                .padding()
             }
-            .frame(height: 250)
-            .padding()
+
         }
     }
 }

--- a/smart-library-app/Types/ReadingBook.swift
+++ b/smart-library-app/Types/ReadingBook.swift
@@ -37,26 +37,35 @@ struct ReadingBook: Hashable {
     }
     
     func getPagesPerHour() -> Int {
-        return bookmark.currentPageNumber / getTotalHoursReading()
+        let totalHoursReading = getTotalHoursReading()
+        if (totalHoursReading == 0) { return 0 }
+        return bookmark.currentPageNumber / totalHoursReading
     }
     
     func getAverageMinutesPerDay() -> Int {
-        return getTotalMinutesReading() / getNumberOfDaysSinceStartedReading()
+        let numberOfDaysSinceStartedReading = getNumberOfDaysSinceStartedReading()
+        if (numberOfDaysSinceStartedReading == 0) { return 0 }
+        return getTotalMinutesReading() / numberOfDaysSinceStartedReading
     }
     
     func getNumberOfDaysSinceStartedReading() -> Int {
+        if (sessions.count == 0) { return 0 }
         return Calendar.current.dateComponents([.day], from: sessions[0].startTime, to: Date.now).day!
     }
     
     func getPagesPerDay() -> Int {
+        let numberOfDaysSinceStartedReading = getNumberOfDaysSinceStartedReading()
+        if (numberOfDaysSinceStartedReading == 0) { return 0 }
         return bookmark.currentPageNumber / getNumberOfDaysSinceStartedReading()
     }
     
     func getAverageMinutesPerSession() -> Int {
+        if (sessions.count == 0) { return 0 }
         return getTotalMinutesReading() / sessions.count
     }
     
     func getAveragePagesPerSession() -> Int {
+        if (sessions.count == 0) { return 0 }
         return bookmark.currentPageNumber / sessions.count
     }
 }


### PR DESCRIPTION
Fixed the issue where the ReadingBookView would crash when a book has no sessions. 

Also added a state to the charts to display a message when there is no data yet. 
<img width="365" alt="Screen Shot 2022-10-18 at 9 59 19 AM" src="https://user-images.githubusercontent.com/27614346/196299555-91b35d8e-5f08-4027-9021-a6a21baaffb5.png">
